### PR TITLE
Sort hash keys

### DIFF
--- a/inc/My/Builder/Unix.pm
+++ b/inc/My/Builder/Unix.pm
@@ -18,7 +18,7 @@ sub get_additional_cflags {
   my $self = shift;
   my @list = ();
   ### any platform specific -L/path/to/libs shoud go here
-  for (keys %$inc_lib_candidates) {
+  for (sort keys %$inc_lib_candidates) {
     push @list, "-I$_" if (-d $_);
   }
   return join(' ', @list);
@@ -36,7 +36,7 @@ sub get_additional_libs {
       $rv{"-Wl,-rpath,$ld"} = 1 if $^O =~ /^linux|dragonfly|.+bsd$/;
     }
   }
-  push @list, (keys %rv);
+  push @list, sort (keys %rv);
   if ($^O eq 'openbsd') {
     my $osver = `uname -r 2>/dev/null`;
     if ($self->notes('perl_libs')->{pthread} || ($osver && $osver < 5.0)) {

--- a/inc/My/Utility.pm
+++ b/inc/My/Utility.pm
@@ -477,7 +477,7 @@ sub find_file {
     no warnings;
     find({ wanted => sub { push @files, rel2abs($_) if /$re/ }, follow => 1, no_chdir => 1 , follow_skip => 2}, $dir);
   };
-  return @files;
+  return sort @files;
 }
 
 sub find_SDL_dir {

--- a/inc/My/Utility.pm
+++ b/inc/My/Utility.pm
@@ -477,7 +477,7 @@ sub find_file {
     no warnings;
     find({ wanted => sub { push @files, rel2abs($_) if /$re/ }, follow => 1, no_chdir => 1 , follow_skip => 2}, $dir);
   };
-  return sort @files;
+  return @files = sort @files; # enforce list context, see `perldoc -f sort`
 }
 
 sub find_SDL_dir {


### PR DESCRIPTION
When building packages (e.g. for openSUSE Linux) in disposable VMs
every build gave a different result.
This patch fixes this by sorting hash keys

See https://reproducible-builds.org/ for why this matters.

was also filed at
https://rt.cpan.org/Public/Bug/Display.html?id=119888